### PR TITLE
HTTP 504 Gateway Timout

### DIFF
--- a/nginx/proxy.conf
+++ b/nginx/proxy.conf
@@ -13,3 +13,8 @@ proxy_set_header X-Forwarded-Port $proxy_x_forwarded_port;
 proxy_set_header Proxy "";
 
 client_max_body_size 500M;
+
+proxy_connect_timeout  600;
+proxy_send_timeout    600;
+proxy_read_timeout    600;
+send_timeout      600;

--- a/nginx/proxy.conf
+++ b/nginx/proxy.conf
@@ -14,7 +14,7 @@ proxy_set_header Proxy "";
 
 client_max_body_size 500M;
 
-proxy_connect_timeout  600;
-proxy_send_timeout    600;
-proxy_read_timeout    600;
-send_timeout      600;
+proxy_connect_timeout 600;
+proxy_send_timeout 600;
+proxy_read_timeout 600;
+send_timeout 600;


### PR DESCRIPTION
Sometime there are appearing 504 gateway timeouts if a script in backend takes to much time. To prevent this, i would like to add some time to proxy connection timeout. For example: build a larger script with: https://github.com/Sebobo/Shel.Neos.Terminal