### PR TITLE
Update nginx.tmpl to use standalone http2 directive

### DIFF
--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -112,10 +112,11 @@ server {
 {{ if (and (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}
 server {
     server_name _; # This is just an invalid value which will never trigger on a real hostname.
-    listen 443 ssl http2;
+    listen 443 ssl;
     {{ if $enable_ipv6 }}
-    listen [::]:443 ssl http2;
+    listen [::]:443 ssl;
     {{ end }}
+    http2 on;
     access_log off;
 
     log_not_found off;
@@ -208,10 +209,11 @@ upstream {{ $upstream_name }} {
 
 server {
     server_name {{ $host }};
-    listen 443 ssl http2 {{ $default_server }};
+    listen 443 ssl {{ $default_server }};
     {{ if $enable_ipv6 }}
-    listen [::]:443 ssl http2 {{ $default_server }};
+    listen [::]:443 ssl {{ $default_server }};
     {{ end }}
+    http2 on;
     access_log /var/log/nginx/access.log vhost;
 
     {{ if eq $network_tag "internal" }}


### PR DESCRIPTION
Fixes a deprecation warning:

`nginx: [warn] the "listen ... http2" directive is deprecated, use the "http2" directive instead in /etc/nginx/conf.d/…`